### PR TITLE
Simplify account statistics component

### DIFF
--- a/src/components/lookup/AccountStatistic.tsx
+++ b/src/components/lookup/AccountStatistic.tsx
@@ -30,21 +30,18 @@ function incrementStats(
   key: keyof StatsData,
   entryKey: number,
   index: number,
-  value: number,
-  incrementTotal = false
+  value: number
 ) {
   const entry = stats[key].entries[entryKey];
   entry.have[index] += value;
-  if (incrementTotal && entry.total) {
+  if (entry.total) {
     entry.total[index] += value;
   }
   
   // If this is the main entry (key 0), also increment top-level totals
   if (entryKey === 0) {
     stats[key].have += value;
-    if (incrementTotal) {
-      stats[key].total += value;
-    }
+    stats[key].total += value;
   }
 }
 
@@ -115,7 +112,7 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
       const rarityIndex = Math.max(0, Math.min(5, (opData.rarity ?? 1) - 1)); // 1-6 -> 0-5
 
       // Operators (counts by rarity)
-      incrementStats(s, "rarity", 0, rarityIndex, 1, true);
+      incrementStats(s, "rarity", 0, rarityIndex, 1);
 
       const owned = !!roster[opId];
       if (owned) {
@@ -124,14 +121,14 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
 
       // Potential (sum of potential slots vs owned potential levels)
       const totalPotentialSlots = opData.potentials?.length ?? 0;
-      incrementStats(s, "potential", 0, rarityIndex, totalPotentialSlots, true);
+      incrementStats(s, "potential", 0, rarityIndex, totalPotentialSlots);
       if (owned) incrementStats(s, "potential", 0, rarityIndex, roster[opId]!.potential ?? 0);
 
       // Elite1 & Elite2 availability vs owned state
       const hasE1 = !!opData.eliteLevels?.some((e) => e.eliteLevel >= 1);
       const hasE2 = !!opData.eliteLevels?.some((e) => e.eliteLevel >= 2);
-      if (hasE1) incrementStats(s, "elite1", 0, rarityIndex, 1, true);
-      if (hasE2) incrementStats(s, "elite2", 0, rarityIndex, 1, true);
+      if (hasE1) incrementStats(s, "elite1", 0, rarityIndex, 1);
+      if (hasE2) incrementStats(s, "elite2", 0, rarityIndex, 1);
       if (owned) {
         const elite = roster[opId]!.elite ?? 0;
         if (elite >= 1) incrementStats(s, "elite1", 0, rarityIndex, 1);
@@ -141,7 +138,7 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
       // Level count: count operators with max levels
       const maxPromotion = MAX_PROMOTION_BY_RARITY[opData.rarity];
       const maxLevel = MAX_LEVEL_BY_RARITY[opData.rarity][maxPromotion];
-      incrementStats(s, "level", 0, rarityIndex, 1, true); // Total operators that can reach max level
+      incrementStats(s, "level", 0, rarityIndex, 1); // Total operators that can reach max level
       if (owned) {
         const op = roster[opId]!;
         const isMaxLevel = op.elite === maxPromotion && op.level === maxLevel;
@@ -152,7 +149,7 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
 
       // Masteries totals (how many mastery steps exist on this operator)
       const masteryGoals = (opData.skillData ?? []).flatMap((sd) => sd.masteries ?? []);
-      incrementStats(s, "masteries", 0, rarityIndex, masteryGoals.length, true);
+      incrementStats(s, "masteries", 0, rarityIndex, masteryGoals.length);
 
       // Modules totals (how many module stages exist on this operator)
       const moduleStages = (opData.moduleData ?? []).reduce((acc, m) => {
@@ -160,7 +157,7 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
         if (!isCn && m.isCnOnly) return acc;
         return acc + (m.stages?.length ?? 0);
       }, 0);
-      incrementStats(s, "modules", 0, rarityIndex, moduleStages, true);
+      incrementStats(s, "modules", 0, rarityIndex, moduleStages);
 
       // Owned-only breakdowns
       if (owned) {
@@ -214,21 +211,6 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
       }
     }
 
-    // Finalize operator-based breakdowns that don't have key 0 entries
-    const finalizeOperatorKey = (key: "masteryOperators" | "moduleOperators") => {
-      const entries = s[key].entries;
-      let haveSum = 0;
-      for (const entry of Object.values(entries)) {
-        for (let i = 0; i < entry.have.length; i++) {
-          haveSum += entry.have[i];
-        }
-      }
-      s[key].have = haveSum;
-      s[key].total = 0; // totals not defined for these buckets
-    };
-
-    finalizeOperatorKey("masteryOperators");
-    finalizeOperatorKey("moduleOperators");
 
     return s;
   }, [roster, isCn]);

--- a/src/components/lookup/AccountStatistic.tsx
+++ b/src/components/lookup/AccountStatistic.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import operatorJson from "data/operators";
 import { LookupData } from "util/hooks/useLookup";
 import { OperatorData } from "types/operators/operator";
+import { MAX_PROMOTION_BY_RARITY, MAX_LEVEL_BY_RARITY } from "util/changeOperator";
 
 // Types requested
 export type StatsEntry = {
@@ -23,8 +24,23 @@ function createArray(length: number, fill = 0): number[] {
   return Array.from({ length }, () => fill);
 }
 
-function sum(arr: number[]): number {
-  return arr.reduce((a, b) => a + b, 0);
+// Helper function to increment values in stats entries
+function incrementValue(
+  entry: { have: number[]; total?: number[] },
+  index: number,
+  value: number,
+  incrementTotal = false
+) {
+  entry.have[index] += value;
+  if (incrementTotal && entry.total) {
+    entry.total[index] += value;
+  }
+}
+
+// Helper function to increment top-level have/total for entries with key 0
+function incrementTopLevel(stats: StatsData, key: keyof StatsData, haveValue: number, totalValue = 0) {
+  stats[key].have += haveValue;
+  stats[key].total += totalValue;
 }
 
 function isOperatorVisible(opData: OperatorData, isCn: boolean): boolean {
@@ -94,38 +110,44 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
       const rarityIndex = Math.max(0, Math.min(5, (opData.rarity ?? 1) - 1)); // 1-6 -> 0-5
 
       // Operators (counts by rarity)
-      s.rarity.entries[0].total![rarityIndex] += 1;
+      incrementValue(s.rarity.entries[0], rarityIndex, 1, true);
 
       const owned = !!roster[opId];
       if (owned) {
-        s.rarity.entries[0].have[rarityIndex] += 1;
+        incrementValue(s.rarity.entries[0], rarityIndex, 1);
       }
 
       // Potential (sum of potential slots vs owned potential levels)
       const totalPotentialSlots = opData.potentials?.length ?? 0;
-      s.potential.entries[0].total![rarityIndex] += totalPotentialSlots;
-      if (owned) s.potential.entries[0].have[rarityIndex] += roster[opId]!.potential ?? 0;
+      incrementValue(s.potential.entries[0], rarityIndex, totalPotentialSlots, true);
+      if (owned) incrementValue(s.potential.entries[0], rarityIndex, roster[opId]!.potential ?? 0);
 
       // Elite1 & Elite2 availability vs owned state
       const hasE1 = !!opData.eliteLevels?.some((e) => e.eliteLevel >= 1);
       const hasE2 = !!opData.eliteLevels?.some((e) => e.eliteLevel >= 2);
-      if (hasE1) s.elite1.entries[0].total![rarityIndex] += 1;
-      if (hasE2) s.elite2.entries[0].total![rarityIndex] += 1;
+      if (hasE1) incrementValue(s.elite1.entries[0], rarityIndex, 1, true);
+      if (hasE2) incrementValue(s.elite2.entries[0], rarityIndex, 1, true);
       if (owned) {
         const elite = roster[opId]!.elite ?? 0;
-        if (elite >= 1) s.elite1.entries[0].have[rarityIndex] += 1;
-        if (elite >= 2) s.elite2.entries[0].have[rarityIndex] += 1;
+        if (elite >= 1) incrementValue(s.elite1.entries[0], rarityIndex, 1);
+        if (elite >= 2) incrementValue(s.elite2.entries[0], rarityIndex, 1);
       }
 
-      // Skill Levels (total upgrades available vs owned upgrades)
-      // JSON lists levels 2..7; we count how many upgrade steps exist (length), and how many the user has (skill_level - 1)
-      const totalSkillUpgrades = opData.skillLevels?.length ?? 0;
-      s.level.entries[0].total![rarityIndex] += totalSkillUpgrades;
-      if (owned) s.level.entries[0].have[rarityIndex] += Math.max(0, (roster[opId]!.skill_level ?? 1) - 1);
+      // Level count: count operators with max levels
+      const maxPromotion = MAX_PROMOTION_BY_RARITY[opData.rarity];
+      const maxLevel = MAX_LEVEL_BY_RARITY[opData.rarity][maxPromotion];
+      s.level.entries[0].total![rarityIndex] += 1; // Total operators that can reach max level
+      if (owned) {
+        const op = roster[opId]!;
+        const isMaxLevel = op.elite === maxPromotion && op.level === maxLevel;
+        if (isMaxLevel) {
+          s.level.entries[0].have[rarityIndex] += 1;
+        }
+      }
 
       // Masteries totals (how many mastery steps exist on this operator)
       const masteryGoals = (opData.skillData ?? []).flatMap((sd) => sd.masteries ?? []);
-      s.masteries.entries[0].total![rarityIndex] += masteryGoals.length;
+      incrementValue(s.masteries.entries[0], rarityIndex, masteryGoals.length, true);
 
       // Modules totals (how many module stages exist on this operator)
       const moduleStages = (opData.moduleData ?? []).reduce((acc, m) => {
@@ -133,58 +155,56 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
         if (!isCn && m.isCnOnly) return acc;
         return acc + (m.stages?.length ?? 0);
       }, 0);
-      s.modules.entries[0].total![rarityIndex] += moduleStages;
+      incrementValue(s.modules.entries[0], rarityIndex, moduleStages, true);
 
       // Owned-only breakdowns
       if (owned) {
         const op = roster[opId]!;
 
-        // Masteries owned: Count of skills at >=1 / >=2 / >=3
+        // Masteries owned: Count unique skills at exactly 1, 2, 3
         const masteryLevels = Array.isArray(op.masteries) ? op.masteries : [];
-        const m1Count = masteryLevels.filter((lvl) => lvl >= 1).length;
-        const m2Count = masteryLevels.filter((lvl) => lvl >= 2).length;
-        const m3Count = masteryLevels.filter((lvl) => lvl >= 3).length;
+        const m1Count = masteryLevels.filter((lvl) => lvl === 1).length;
+        const m2Count = masteryLevels.filter((lvl) => lvl === 2).length;
+        const m3Count = masteryLevels.filter((lvl) => lvl === 3).length;
 
-        // main spread (by rarity 1..6)
-        s.masteries.entries[0].have[rarityIndex] += m1Count + m2Count + m3Count - (m2Count + m3Count) + (m2Count) + (m3Count);
-        // Above line simplifies to m1Count + m2Count + m3Count but keeps intent clear
-        s.masteries.entries[0].have[rarityIndex] += 0; // clarity
+        // main spread (by rarity 1..6) - total count of all mastery levels
+        incrementValue(s.masteries.entries[0], rarityIndex, m1Count + m2Count + m3Count);
 
         // additional breakdown for rarities 4..6 only
         if (opData.rarity >= 4) {
           const ri = opData.rarity - 4; // 4->0, 5->1, 6->2
-          if (m1Count > 0) s.masteries.entries[1].have[ri] += m1Count;
-          if (m2Count > 0) s.masteries.entries[2].have[ri] += m2Count;
-          if (m3Count > 0) s.masteries.entries[3].have[ri] += m3Count;
+          if (m1Count > 0) incrementValue(s.masteries.entries[1], ri, m1Count);
+          if (m2Count > 0) incrementValue(s.masteries.entries[2], ri, m2Count);
+          if (m3Count > 0) incrementValue(s.masteries.entries[3], ri, m3Count);
 
           // masteryOperators: by operator flags
-          if (m1Count > 0) s.masteryOperators.entries[1].have[ri] += 1;
-          if (m2Count > 0) s.masteryOperators.entries[2].have[ri] += 1;
-          if (m3Count > 0) s.masteryOperators.entries[3].have[ri] += 1;
-          if (m3Count >= 2) s.masteryOperators.entries[6].have[ri] += 1;
-          if (m3Count >= 3) s.masteryOperators.entries[9].have[ri] += 1;
+          if (m1Count > 0) incrementValue(s.masteryOperators.entries[1], ri, 1);
+          if (m2Count > 0) incrementValue(s.masteryOperators.entries[2], ri, 1);
+          if (m3Count > 0) incrementValue(s.masteryOperators.entries[3], ri, 1);
+          if (m3Count >= 2) incrementValue(s.masteryOperators.entries[6], ri, 1);
+          if (m3Count >= 3) incrementValue(s.masteryOperators.entries[9], ri, 1);
         }
 
-        // Modules owned: Count of module stages achieved across all modules
+        // Modules owned: Count unique module stages at exactly 1, 2, 3
         const moduleLevels = Object.values(op.modules ?? {});
-        const mod1Count = moduleLevels.filter((lvl) => lvl >= 1).length;
-        const mod2Count = moduleLevels.filter((lvl) => lvl >= 2).length;
-        const mod3Count = moduleLevels.filter((lvl) => lvl >= 3).length;
+        const mod1Count = moduleLevels.filter((lvl) => lvl === 1).length;
+        const mod2Count = moduleLevels.filter((lvl) => lvl === 2).length;
+        const mod3Count = moduleLevels.filter((lvl) => lvl === 3).length;
 
-        s.modules.entries[0].have[rarityIndex] += mod1Count + mod2Count + mod3Count - (mod2Count + mod3Count) + mod2Count + mod3Count;
-        s.modules.entries[0].have[rarityIndex] += 0; // clarity
+        // main spread (by rarity 1..6) - total count of all module levels
+        incrementValue(s.modules.entries[0], rarityIndex, mod1Count + mod2Count + mod3Count);
 
         if (opData.rarity >= 4) {
           const ri = opData.rarity - 4;
-          if (mod1Count > 0) s.modules.entries[1].have[ri] += mod1Count;
-          if (mod2Count > 0) s.modules.entries[2].have[ri] += mod2Count;
-          if (mod3Count > 0) s.modules.entries[3].have[ri] += mod3Count;
+          if (mod1Count > 0) incrementValue(s.modules.entries[1], ri, mod1Count);
+          if (mod2Count > 0) incrementValue(s.modules.entries[2], ri, mod2Count);
+          if (mod3Count > 0) incrementValue(s.modules.entries[3], ri, mod3Count);
 
-          if (mod1Count > 0) s.moduleOperators.entries[1].have[ri] += 1;
-          if (mod2Count > 0) s.moduleOperators.entries[2].have[ri] += 1;
-          if (mod3Count > 0) s.moduleOperators.entries[3].have[ri] += 1;
-          if (mod3Count >= 2) s.moduleOperators.entries[6].have[ri] += 1;
-          if (mod3Count >= 3) s.moduleOperators.entries[9].have[ri] += 1;
+          if (mod1Count > 0) incrementValue(s.moduleOperators.entries[1], ri, 1);
+          if (mod2Count > 0) incrementValue(s.moduleOperators.entries[2], ri, 1);
+          if (mod3Count > 0) incrementValue(s.moduleOperators.entries[3], ri, 1);
+          if (mod3Count >= 2) incrementValue(s.moduleOperators.entries[6], ri, 1);
+          if (mod3Count >= 3) incrementValue(s.moduleOperators.entries[9], ri, 1);
         }
       }
     }
@@ -193,8 +213,12 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
     const finalizeKey = (key: keyof StatsData) => {
       const e = s[key].entries[0];
       if (!e) return;
-      const haveSum = sum(e.have);
-      const totalSum = sum(e.total ?? []);
+      let haveSum = 0;
+      let totalSum = 0;
+      for (let i = 0; i < e.have.length; i++) {
+        haveSum += e.have[i];
+        if (e.total) totalSum += e.total[i];
+      }
       s[key].have = haveSum;
       s[key].total = totalSum;
     };
@@ -210,8 +234,12 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
     // For operator-based breakdowns without a 0 entry, sum all entries arrays
     const finalizeOperatorKey = (key: "masteryOperators" | "moduleOperators") => {
       const entries = s[key].entries;
-      const arrays = Object.values(entries).map((x) => x.have);
-      const haveSum = arrays.reduce((acc, arr) => acc + sum(arr), 0);
+      let haveSum = 0;
+      for (const entry of Object.values(entries)) {
+        for (let i = 0; i < entry.have.length; i++) {
+          haveSum += entry.have[i];
+        }
+      }
       s[key].have = haveSum;
       s[key].total = 0; // totals not defined for these buckets
     };

--- a/src/components/lookup/AccountStatistic.tsx
+++ b/src/components/lookup/AccountStatistic.tsx
@@ -24,23 +24,28 @@ function createArray(length: number, fill = 0): number[] {
   return Array.from({ length }, () => fill);
 }
 
-// Helper function to increment values in stats entries
-function incrementValue(
-  entry: { have: number[]; total?: number[] },
+// Helper function to increment values in stats entries and top-level totals
+function incrementStats(
+  stats: StatsData,
+  key: keyof StatsData,
+  entryKey: number,
   index: number,
   value: number,
   incrementTotal = false
 ) {
+  const entry = stats[key].entries[entryKey];
   entry.have[index] += value;
   if (incrementTotal && entry.total) {
     entry.total[index] += value;
   }
-}
-
-// Helper function to increment top-level have/total for entries with key 0
-function incrementTopLevel(stats: StatsData, key: keyof StatsData, haveValue: number, totalValue = 0) {
-  stats[key].have += haveValue;
-  stats[key].total += totalValue;
+  
+  // If this is the main entry (key 0), also increment top-level totals
+  if (entryKey === 0) {
+    stats[key].have += value;
+    if (incrementTotal) {
+      stats[key].total += value;
+    }
+  }
 }
 
 function isOperatorVisible(opData: OperatorData, isCn: boolean): boolean {
@@ -110,44 +115,44 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
       const rarityIndex = Math.max(0, Math.min(5, (opData.rarity ?? 1) - 1)); // 1-6 -> 0-5
 
       // Operators (counts by rarity)
-      incrementValue(s.rarity.entries[0], rarityIndex, 1, true);
+      incrementStats(s, "rarity", 0, rarityIndex, 1, true);
 
       const owned = !!roster[opId];
       if (owned) {
-        incrementValue(s.rarity.entries[0], rarityIndex, 1);
+        incrementStats(s, "rarity", 0, rarityIndex, 1);
       }
 
       // Potential (sum of potential slots vs owned potential levels)
       const totalPotentialSlots = opData.potentials?.length ?? 0;
-      incrementValue(s.potential.entries[0], rarityIndex, totalPotentialSlots, true);
-      if (owned) incrementValue(s.potential.entries[0], rarityIndex, roster[opId]!.potential ?? 0);
+      incrementStats(s, "potential", 0, rarityIndex, totalPotentialSlots, true);
+      if (owned) incrementStats(s, "potential", 0, rarityIndex, roster[opId]!.potential ?? 0);
 
       // Elite1 & Elite2 availability vs owned state
       const hasE1 = !!opData.eliteLevels?.some((e) => e.eliteLevel >= 1);
       const hasE2 = !!opData.eliteLevels?.some((e) => e.eliteLevel >= 2);
-      if (hasE1) incrementValue(s.elite1.entries[0], rarityIndex, 1, true);
-      if (hasE2) incrementValue(s.elite2.entries[0], rarityIndex, 1, true);
+      if (hasE1) incrementStats(s, "elite1", 0, rarityIndex, 1, true);
+      if (hasE2) incrementStats(s, "elite2", 0, rarityIndex, 1, true);
       if (owned) {
         const elite = roster[opId]!.elite ?? 0;
-        if (elite >= 1) incrementValue(s.elite1.entries[0], rarityIndex, 1);
-        if (elite >= 2) incrementValue(s.elite2.entries[0], rarityIndex, 1);
+        if (elite >= 1) incrementStats(s, "elite1", 0, rarityIndex, 1);
+        if (elite >= 2) incrementStats(s, "elite2", 0, rarityIndex, 1);
       }
 
       // Level count: count operators with max levels
       const maxPromotion = MAX_PROMOTION_BY_RARITY[opData.rarity];
       const maxLevel = MAX_LEVEL_BY_RARITY[opData.rarity][maxPromotion];
-      s.level.entries[0].total![rarityIndex] += 1; // Total operators that can reach max level
+      incrementStats(s, "level", 0, rarityIndex, 1, true); // Total operators that can reach max level
       if (owned) {
         const op = roster[opId]!;
         const isMaxLevel = op.elite === maxPromotion && op.level === maxLevel;
         if (isMaxLevel) {
-          s.level.entries[0].have[rarityIndex] += 1;
+          incrementStats(s, "level", 0, rarityIndex, 1);
         }
       }
 
       // Masteries totals (how many mastery steps exist on this operator)
       const masteryGoals = (opData.skillData ?? []).flatMap((sd) => sd.masteries ?? []);
-      incrementValue(s.masteries.entries[0], rarityIndex, masteryGoals.length, true);
+      incrementStats(s, "masteries", 0, rarityIndex, masteryGoals.length, true);
 
       // Modules totals (how many module stages exist on this operator)
       const moduleStages = (opData.moduleData ?? []).reduce((acc, m) => {
@@ -155,7 +160,7 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
         if (!isCn && m.isCnOnly) return acc;
         return acc + (m.stages?.length ?? 0);
       }, 0);
-      incrementValue(s.modules.entries[0], rarityIndex, moduleStages, true);
+      incrementStats(s, "modules", 0, rarityIndex, moduleStages, true);
 
       // Owned-only breakdowns
       if (owned) {
@@ -168,21 +173,21 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
         const m3Count = masteryLevels.filter((lvl) => lvl === 3).length;
 
         // main spread (by rarity 1..6) - total count of all mastery levels
-        incrementValue(s.masteries.entries[0], rarityIndex, m1Count + m2Count + m3Count);
+        incrementStats(s, "masteries", 0, rarityIndex, m1Count + m2Count + m3Count);
 
         // additional breakdown for rarities 4..6 only
         if (opData.rarity >= 4) {
           const ri = opData.rarity - 4; // 4->0, 5->1, 6->2
-          if (m1Count > 0) incrementValue(s.masteries.entries[1], ri, m1Count);
-          if (m2Count > 0) incrementValue(s.masteries.entries[2], ri, m2Count);
-          if (m3Count > 0) incrementValue(s.masteries.entries[3], ri, m3Count);
+          if (m1Count > 0) incrementStats(s, "masteries", 1, ri, m1Count);
+          if (m2Count > 0) incrementStats(s, "masteries", 2, ri, m2Count);
+          if (m3Count > 0) incrementStats(s, "masteries", 3, ri, m3Count);
 
           // masteryOperators: by operator flags
-          if (m1Count > 0) incrementValue(s.masteryOperators.entries[1], ri, 1);
-          if (m2Count > 0) incrementValue(s.masteryOperators.entries[2], ri, 1);
-          if (m3Count > 0) incrementValue(s.masteryOperators.entries[3], ri, 1);
-          if (m3Count >= 2) incrementValue(s.masteryOperators.entries[6], ri, 1);
-          if (m3Count >= 3) incrementValue(s.masteryOperators.entries[9], ri, 1);
+          if (m1Count > 0) incrementStats(s, "masteryOperators", 1, ri, 1);
+          if (m2Count > 0) incrementStats(s, "masteryOperators", 2, ri, 1);
+          if (m3Count > 0) incrementStats(s, "masteryOperators", 3, ri, 1);
+          if (m3Count >= 2) incrementStats(s, "masteryOperators", 6, ri, 1);
+          if (m3Count >= 3) incrementStats(s, "masteryOperators", 9, ri, 1);
         }
 
         // Modules owned: Count unique module stages at exactly 1, 2, 3
@@ -192,46 +197,24 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
         const mod3Count = moduleLevels.filter((lvl) => lvl === 3).length;
 
         // main spread (by rarity 1..6) - total count of all module levels
-        incrementValue(s.modules.entries[0], rarityIndex, mod1Count + mod2Count + mod3Count);
+        incrementStats(s, "modules", 0, rarityIndex, mod1Count + mod2Count + mod3Count);
 
         if (opData.rarity >= 4) {
           const ri = opData.rarity - 4;
-          if (mod1Count > 0) incrementValue(s.modules.entries[1], ri, mod1Count);
-          if (mod2Count > 0) incrementValue(s.modules.entries[2], ri, mod2Count);
-          if (mod3Count > 0) incrementValue(s.modules.entries[3], ri, mod3Count);
+          if (mod1Count > 0) incrementStats(s, "modules", 1, ri, mod1Count);
+          if (mod2Count > 0) incrementStats(s, "modules", 2, ri, mod2Count);
+          if (mod3Count > 0) incrementStats(s, "modules", 3, ri, mod3Count);
 
-          if (mod1Count > 0) incrementValue(s.moduleOperators.entries[1], ri, 1);
-          if (mod2Count > 0) incrementValue(s.moduleOperators.entries[2], ri, 1);
-          if (mod3Count > 0) incrementValue(s.moduleOperators.entries[3], ri, 1);
-          if (mod3Count >= 2) incrementValue(s.moduleOperators.entries[6], ri, 1);
-          if (mod3Count >= 3) incrementValue(s.moduleOperators.entries[9], ri, 1);
+          if (mod1Count > 0) incrementStats(s, "moduleOperators", 1, ri, 1);
+          if (mod2Count > 0) incrementStats(s, "moduleOperators", 2, ri, 1);
+          if (mod3Count > 0) incrementStats(s, "moduleOperators", 3, ri, 1);
+          if (mod3Count >= 2) incrementStats(s, "moduleOperators", 6, ri, 1);
+          if (mod3Count >= 3) incrementStats(s, "moduleOperators", 9, ri, 1);
         }
       }
     }
 
-    // Aggregate sums into the top-level have/total fields per key from their main (0) entry arrays
-    const finalizeKey = (key: keyof StatsData) => {
-      const e = s[key].entries[0];
-      if (!e) return;
-      let haveSum = 0;
-      let totalSum = 0;
-      for (let i = 0; i < e.have.length; i++) {
-        haveSum += e.have[i];
-        if (e.total) totalSum += e.total[i];
-      }
-      s[key].have = haveSum;
-      s[key].total = totalSum;
-    };
-
-    finalizeKey("rarity");
-    finalizeKey("elite1");
-    finalizeKey("elite2");
-    finalizeKey("level");
-    finalizeKey("masteries");
-    finalizeKey("modules");
-    finalizeKey("potential");
-
-    // For operator-based breakdowns without a 0 entry, sum all entries arrays
+    // Finalize operator-based breakdowns that don't have key 0 entries
     const finalizeOperatorKey = (key: "masteryOperators" | "moduleOperators") => {
       const entries = s[key].entries;
       let haveSum = 0;

--- a/src/components/lookup/AccountStatistic.tsx
+++ b/src/components/lookup/AccountStatistic.tsx
@@ -39,7 +39,6 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
   const stats = React.useMemo<StatsData>(() => {
     // Initialize stats structure with zeroes
     const s: StatsData = {
-      operators: { entries: { 0: { have: createArray(6), total: createArray(6) } }, have: 0, total: 0 },
       rarity: { entries: { 0: { have: createArray(6), total: createArray(6) } }, have: 0, total: 0 },
       elite1: { entries: { 0: { have: createArray(6), total: createArray(6) } }, have: 0, total: 0 },
       elite2: { entries: { 0: { have: createArray(6), total: createArray(6) } }, have: 0, total: 0 },
@@ -95,12 +94,10 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
       const rarityIndex = Math.max(0, Math.min(5, (opData.rarity ?? 1) - 1)); // 1-6 -> 0-5
 
       // Operators (counts by rarity)
-      s.operators.entries[0].total![rarityIndex] += 1;
-      s.rarity.entries[0].total![rarityIndex] += 1; // keep separate as requested
+      s.rarity.entries[0].total![rarityIndex] += 1;
 
       const owned = !!roster[opId];
       if (owned) {
-        s.operators.entries[0].have[rarityIndex] += 1;
         s.rarity.entries[0].have[rarityIndex] += 1;
       }
 
@@ -202,7 +199,6 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
       s[key].total = totalSum;
     };
 
-    finalizeKey("operators");
     finalizeKey("rarity");
     finalizeKey("elite1");
     finalizeKey("elite2");


### PR DESCRIPTION
Remove the redundant `operators` key from `AccountStatistic.tsx` because it duplicated the functionality of the `rarity` key.

---
<a href="https://cursor.com/background-agent?bcId=bc-35349289-a85a-417f-85c4-c9f9efc1bb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-35349289-a85a-417f-85c4-c9f9efc1bb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

