### PR TITLE
Fix operator rarity and potential counting logic

### DIFF
--- a/src/components/lookup/AccountStatistic.tsx
+++ b/src/components/lookup/AccountStatistic.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import operatorJson from "data/operators";
 import { LookupData } from "util/hooks/useLookup";
 import { OperatorData } from "types/operators/operator";
-import { MAX_PROMOTION_BY_RARITY, MAX_LEVEL_BY_RARITY } from "util/changeOperator";
+import { MAX_PROMOTION_BY_RARITY, MAX_LEVEL_BY_RARITY, getMaxPotentialById } from "util/changeOperator";
 
 // Types requested
 export type StatsEntry = {
@@ -30,18 +30,24 @@ function incrementStats(
   key: keyof StatsData,
   entryKey: number,
   index: number,
-  value: number
+  value: number,
+  isTotal = false
 ) {
   const entry = stats[key].entries[entryKey];
-  entry.have[index] += value;
-  if (entry.total) {
-    entry.total[index] += value;
-  }
-  
-  // If this is the main entry (key 0), also increment top-level totals
-  if (entryKey === 0) {
-    stats[key].have += value;
-    stats[key].total += value;
+  if (isTotal) {
+    if (entry.total) {
+      entry.total[index] += value;
+    }
+    // Only increment top-level total for totals
+    if (entryKey === 0) {
+      stats[key].total += value;
+    }
+  } else {
+    entry.have[index] += value;
+    // Only increment top-level have for have values
+    if (entryKey === 0) {
+      stats[key].have += value;
+    }
   }
 }
 
@@ -81,7 +87,7 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
         have: 0,
         total: 0,
       },
-      potential: { entries: { 0: { have: createArray(6), total: createArray(6) } }, have: 0, total: 0 },
+      potential: { entries: { 0: { have: createArray(6) } }, have: 0, total: 0 },
       masteryOperators: {
         entries: {
           1: { have: createArray(3) },
@@ -111,45 +117,48 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
       if (!isOperatorVisible(opData, isCn)) continue;
       const rarityIndex = Math.max(0, Math.min(5, (opData.rarity ?? 1) - 1)); // 1-6 -> 0-5
 
-      // Operators (counts by rarity)
-      incrementStats(s, "rarity", 0, rarityIndex, 1);
+      // Operators (counts by rarity) - total count
+      incrementStats(s, "rarity", 0, rarityIndex, 1, true);
 
       const owned = !!roster[opId];
       if (owned) {
-        incrementStats(s, "rarity", 0, rarityIndex, 1);
+        // Only increment have if operator is owned
+        incrementStats(s, "rarity", 0, rarityIndex, 1, false);
       }
 
-      // Potential (sum of potential slots vs owned potential levels)
-      const totalPotentialSlots = opData.potentials?.length ?? 0;
-      incrementStats(s, "potential", 0, rarityIndex, totalPotentialSlots);
-      if (owned) incrementStats(s, "potential", 0, rarityIndex, roster[opId]!.potential ?? 0);
+      // Potential - max potential is 6, only count max potentials in have array
+      const maxPotential = getMaxPotentialById(opId);
+      incrementStats(s, "potential", 0, rarityIndex, maxPotential, true);
+      if (owned) {
+        const currentPotential = roster[opId]!.potential ?? 0;
+        incrementStats(s, "potential", 0, rarityIndex, currentPotential, false);
+      }
 
-      // Elite1 & Elite2 availability vs owned state
-      const hasE1 = !!opData.eliteLevels?.some((e) => e.eliteLevel >= 1);
-      const hasE2 = !!opData.eliteLevels?.some((e) => e.eliteLevel >= 2);
-      if (hasE1) incrementStats(s, "elite1", 0, rarityIndex, 1);
-      if (hasE2) incrementStats(s, "elite2", 0, rarityIndex, 1);
+      // Elite1 & Elite2 - use MAX_PROMOTION_BY_RARITY helper
+      const maxPromotion = MAX_PROMOTION_BY_RARITY[opData.rarity];
+      if (maxPromotion >= 1) incrementStats(s, "elite1", 0, rarityIndex, 1, true);
+      if (maxPromotion >= 2) incrementStats(s, "elite2", 0, rarityIndex, 1, true);
       if (owned) {
         const elite = roster[opId]!.elite ?? 0;
-        if (elite >= 1) incrementStats(s, "elite1", 0, rarityIndex, 1);
-        if (elite >= 2) incrementStats(s, "elite2", 0, rarityIndex, 1);
+        if (elite >= 1) incrementStats(s, "elite1", 0, rarityIndex, 1, false);
+        if (elite >= 2) incrementStats(s, "elite2", 0, rarityIndex, 1, false);
       }
 
       // Level count: count operators with max levels
       const maxPromotion = MAX_PROMOTION_BY_RARITY[opData.rarity];
       const maxLevel = MAX_LEVEL_BY_RARITY[opData.rarity][maxPromotion];
-      incrementStats(s, "level", 0, rarityIndex, 1); // Total operators that can reach max level
+      incrementStats(s, "level", 0, rarityIndex, 1, true); // Total operators that can reach max level
       if (owned) {
         const op = roster[opId]!;
         const isMaxLevel = op.elite === maxPromotion && op.level === maxLevel;
         if (isMaxLevel) {
-          incrementStats(s, "level", 0, rarityIndex, 1);
+          incrementStats(s, "level", 0, rarityIndex, 1, false);
         }
       }
 
       // Masteries totals (how many mastery steps exist on this operator)
       const masteryGoals = (opData.skillData ?? []).flatMap((sd) => sd.masteries ?? []);
-      incrementStats(s, "masteries", 0, rarityIndex, masteryGoals.length);
+      incrementStats(s, "masteries", 0, rarityIndex, masteryGoals.length, true);
 
       // Modules totals (how many module stages exist on this operator)
       const moduleStages = (opData.moduleData ?? []).reduce((acc, m) => {
@@ -157,7 +166,7 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
         if (!isCn && m.isCnOnly) return acc;
         return acc + (m.stages?.length ?? 0);
       }, 0);
-      incrementStats(s, "modules", 0, rarityIndex, moduleStages);
+      incrementStats(s, "modules", 0, rarityIndex, moduleStages, true);
 
       // Owned-only breakdowns
       if (owned) {
@@ -170,21 +179,21 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
         const m3Count = masteryLevels.filter((lvl) => lvl === 3).length;
 
         // main spread (by rarity 1..6) - total count of all mastery levels
-        incrementStats(s, "masteries", 0, rarityIndex, m1Count + m2Count + m3Count);
+        incrementStats(s, "masteries", 0, rarityIndex, m1Count + m2Count + m3Count, false);
 
         // additional breakdown for rarities 4..6 only
         if (opData.rarity >= 4) {
           const ri = opData.rarity - 4; // 4->0, 5->1, 6->2
-          if (m1Count > 0) incrementStats(s, "masteries", 1, ri, m1Count);
-          if (m2Count > 0) incrementStats(s, "masteries", 2, ri, m2Count);
-          if (m3Count > 0) incrementStats(s, "masteries", 3, ri, m3Count);
+          if (m1Count > 0) incrementStats(s, "masteries", 1, ri, m1Count, false);
+          if (m2Count > 0) incrementStats(s, "masteries", 2, ri, m2Count, false);
+          if (m3Count > 0) incrementStats(s, "masteries", 3, ri, m3Count, false);
 
-          // masteryOperators: by operator flags
-          if (m1Count > 0) incrementStats(s, "masteryOperators", 1, ri, 1);
-          if (m2Count > 0) incrementStats(s, "masteryOperators", 2, ri, 1);
-          if (m3Count > 0) incrementStats(s, "masteryOperators", 3, ri, 1);
-          if (m3Count >= 2) incrementStats(s, "masteryOperators", 6, ri, 1);
-          if (m3Count >= 3) incrementStats(s, "masteryOperators", 9, ri, 1);
+          // masteryOperators: by operator flags - increment +1 per operator, not amounts
+          if (m1Count > 0) incrementStats(s, "masteryOperators", 1, ri, 1, false);
+          if (m2Count > 0) incrementStats(s, "masteryOperators", 2, ri, 1, false);
+          if (m3Count > 0) incrementStats(s, "masteryOperators", 3, ri, 1, false);
+          if (m3Count >= 2) incrementStats(s, "masteryOperators", 6, ri, 1, false);
+          if (m3Count >= 3) incrementStats(s, "masteryOperators", 9, ri, 1, false);
         }
 
         // Modules owned: Count unique module stages at exactly 1, 2, 3
@@ -194,19 +203,20 @@ const AccountStatistic: React.FC<{ data: NonNullable<LookupData> }> = ({ data })
         const mod3Count = moduleLevels.filter((lvl) => lvl === 3).length;
 
         // main spread (by rarity 1..6) - total count of all module levels
-        incrementStats(s, "modules", 0, rarityIndex, mod1Count + mod2Count + mod3Count);
+        incrementStats(s, "modules", 0, rarityIndex, mod1Count + mod2Count + mod3Count, false);
 
         if (opData.rarity >= 4) {
           const ri = opData.rarity - 4;
-          if (mod1Count > 0) incrementStats(s, "modules", 1, ri, mod1Count);
-          if (mod2Count > 0) incrementStats(s, "modules", 2, ri, mod2Count);
-          if (mod3Count > 0) incrementStats(s, "modules", 3, ri, mod3Count);
+          if (mod1Count > 0) incrementStats(s, "modules", 1, ri, mod1Count, false);
+          if (mod2Count > 0) incrementStats(s, "modules", 2, ri, mod2Count, false);
+          if (mod3Count > 0) incrementStats(s, "modules", 3, ri, mod3Count, false);
 
-          if (mod1Count > 0) incrementStats(s, "moduleOperators", 1, ri, 1);
-          if (mod2Count > 0) incrementStats(s, "moduleOperators", 2, ri, 1);
-          if (mod3Count > 0) incrementStats(s, "moduleOperators", 3, ri, 1);
-          if (mod3Count >= 2) incrementStats(s, "moduleOperators", 6, ri, 1);
-          if (mod3Count >= 3) incrementStats(s, "moduleOperators", 9, ri, 1);
+          // moduleOperators: by operator flags - increment +1 per operator, not amounts
+          if (mod1Count > 0) incrementStats(s, "moduleOperators", 1, ri, 1, false);
+          if (mod2Count > 0) incrementStats(s, "moduleOperators", 2, ri, 1, false);
+          if (mod3Count > 0) incrementStats(s, "moduleOperators", 3, ri, 1, false);
+          if (mod3Count >= 2) incrementStats(s, "moduleOperators", 6, ri, 1, false);
+          if (mod3Count >= 3) incrementStats(s, "moduleOperators", 9, ri, 1, false);
         }
       }
     }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes inaccurate operator statistics in `AccountStatistic.tsx` by correcting rarity double-counting, differentiating 'have' and 'total' values, and streamlining potential and elite calculations.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `incrementStats` function did not properly distinguish between "total available" and "user owned" counts, leading to `have` and `total` arrays often having identical values. This also caused rarity counts to be doubled. The potential and elite calculations were inconsistent with helper functions, leading to incorrect statistics. This PR introduces an `isTotal` parameter to `incrementStats` and updates the logic to correctly reflect owned vs. total values.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a64598a-e9b1-407f-b936-0f25fb4729ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a64598a-e9b1-407f-b936-0f25fb4729ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

